### PR TITLE
Fixed refresh token expiration docs

### DIFF
--- a/content/docs/authorization/common-auth-issues/index.md
+++ b/content/docs/authorization/common-auth-issues/index.md
@@ -104,7 +104,8 @@ bb-api-subscription-key: 77f137116...480d633
 
 #### Expired Token
 
-The access token expires in {{ stache.config.access_token_expiration_minutes }} minutes.  With the [Authorization Code Flow]({{ stache.config.guide_web_api_authorization_auth_code_flow }}), each time you refresh your tokens, you'll get a new access and refresh token.  As of now, refresh tokens do _not_ expire.  However, we are planning on revisiting this in the future.  You can expect some type of sliding window for refresh token expiration. So, as long as your application connects at least once within that window, you won't have to re-authenticate with the client.
+The access token expires in {{ stache.config.access_token_expiration_minutes }} minutes.  With the [Authorization Code Flow]({{ stache.config.guide_web_api_authorization_auth_code_flow }}), each time you refresh your tokens, you'll get a new access and refresh token.  
+
+Refresh tokens will also expire, but after a much longer period of time (currently, {{ stache.config.refresh_token_expiration_days }} days). Using a sliding window, each time you exchange your refresh token for a new access token, we will issue a new refresh token as well. As long as your application connects to the SKY API at least once within the window, you will be able to continue accessing the Blackbaud customer's data indefinitely (or until they deactivate your application).
 
 If your access token _and_ refresh token have expired, the user will have to re-authenticate and consent.
-


### PR DESCRIPTION
This documentation was out of date and did not match similar content elsewhere:

https://apidocs.sky.blackbaud.com/docs/authorization/#token-expiration
https://apidocs.sky.blackbaud.com/docs/authorization/auth-code-flow (see steps 4, 5, and 7)
https://apidocs.sky.blackbaud.com/support/faq (see the “Tokens” section)