### PR TITLE
Angular Entity Reference component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .tmp/
+.vscode
 Thumbs.db
 vendor/
 build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,17 @@ For simple changes, we recommend that you edit files directly in GitHub. You can
 
 For more substantive changes:
 
-1. Fork and then clone the repo. 
+1. Fork and then clone the repo.
 2. Make your changes.
 3. Push your changes to your fork and submit a pull request. Your request should merge into the `develop` branch. 
 
 We will review your pull request and, if necessary, provide suggestions for changes or improvements. 
+
+## Running Demo
+
+To run the demo:
+
+1. Run `npm install`
+2. Run `grunt`
+3. Run `stache serve`
+4. Open browser to `http://localhost:4000`

--- a/content/api/entity-reference/index.html
+++ b/content/api/entity-reference/index.html
@@ -10,60 +10,67 @@ title: Entity Reference
 
 <h1>{{ name }}</h1>
 
+<div class="showcase">
+    <div class="row">
 
-
-    <div class="showcase">
-        <div class="row">
-
-            <div class="col-sm-4">
-                <i class="fa fa-fw fa-3x fa-university showcase-icon"></i>
-                <div class="showcase-desc">
-                    <h2>
-                        <a href="{{ stache.config.accounts_payable_entity_reference }}">Accounts Payable</a>
-                    </h2>
-                    <p>Describes the entity and type representations for common items that the Accounts Payable API uses.</p>
-                </div>
+        <div class="col-sm-4">
+            <i class="fa fa-fw fa-3x fa-university showcase-icon"></i>
+            <div class="showcase-desc">
+                <h2>
+                    <a href="{{ stache.config.accounts_payable_entity_reference }}">Accounts Payable</a>
+                </h2>
+                <p>Describes the entity and type representations for common items that the Accounts Payable API uses.</p>
             </div>
+        </div>
 
-            <div class="col-sm-4">
-                <i class="fa fa-fw fa-3x fa-user showcase-icon"></i>
-                <div class="showcase-desc">
-                    <h2>
-                        <a href="{{ stache.config.constituent_entity_reference }}">Constituent</a>
-                    </h2>
-                    <p>Describes the entity and type representations for common items that the Constituent API uses.</p>
-                </div>
+        <div class="col-sm-4">
+            <i class="fa fa-fw fa-3x fa-user showcase-icon"></i>
+            <div class="showcase-desc">
+                <h2>
+                    <a href="{{ stache.config.constituent_entity_reference }}">Constituent</a>
+                </h2>
+                <p>Describes the entity and type representations for common items that the Constituent API uses.</p>
             </div>
+        </div>
 
-            <div class="col-sm-4">
-                <i class="fa fa-fw fa-3x fa-line-chart showcase-icon"></i>
-                <div class="showcase-desc">
-                    <h2>
-                        <a href="{{ stache.config.fundraising_entity_reference }}">Fundraising (Beta)</a>
-                    </h2>
-                    <p>Describes the entity and type representations for common items that the Fundraising API uses.</p>
-                </div>
+        <div class="col-sm-4">
+            <i class="fa fa-fw fa-3x fa-line-chart showcase-icon"></i>
+            <div class="showcase-desc">
+                <h2>
+                    <a href="{{ stache.config.fundraising_entity_reference }}">Fundraising (Beta)</a>
+                </h2>
+                <p>Describes the entity and type representations for common items that the Fundraising API uses.</p>
             </div>
+        </div>
 
-            <div class="col-sm-4">
-                <i class="fa fa-fw fa-3x fa-book showcase-icon"></i>
-                <div class="showcase-desc">
-                    <h2>
-                        <a href="{{ stache.config.general_ledger_entity_reference }}">General Ledger</a>
-                    </h2>
-                    <p>Describes the entity and type representations for common items that the General Ledger API uses.</p>
-                </div>
+        <div class="col-sm-4">
+            <i class="fa fa-fw fa-3x fa-book showcase-icon"></i>
+            <div class="showcase-desc">
+                <h2>
+                    <a href="{{ stache.config.general_ledger_entity_reference }}">General Ledger</a>
+                </h2>
+                <p>Describes the entity and type representations for common items that the General Ledger API uses.</p>
             </div>
+        </div>
 
-            <div class="col-sm-4">
-                <i class="fa fa-fw fa-3x fa-gift showcase-icon"></i>
-                <div class="showcase-desc">
-                    <h2>
-                        <a href="{{ stache.config.gift_entity_reference }}">Gift (Beta)</a>
-                    </h2>
-                    <p>Describes the entity and type representations for common items that the Gift API uses.</p>
-                </div>
+        <div class="col-sm-4">
+            <i class="fa fa-fw fa-3x fa-gift showcase-icon"></i>
+            <div class="showcase-desc">
+                <h2>
+                    <a href="{{ stache.config.gift_entity_reference }}">Gift (Beta)</a>
+                </h2>
+                <p>Describes the entity and type representations for common items that the Gift API uses.</p>
             </div>
+        </div>
 
+        <div class="col-sm-4">
+            <i class="fa fa-fw fa-3x fa-group showcase-icon"></i>
+            <div class="showcase-desc">
+                <h2>
+                    <a href="{{ stache.config.peer_to_peer_entity_reference }}">Peer to Peer</a>
+                </h2>
+                <p>Describes the entity and type representations for common items that the Peer to Peer API uses.</p>
+            </div>
         </div>
     </div>
+</div>

--- a/content/api/entity-reference/index.html
+++ b/content/api/entity-reference/index.html
@@ -62,15 +62,5 @@ title: Entity Reference
                 <p>Describes the entity and type representations for common items that the Gift API uses.</p>
             </div>
         </div>
-
-        <div class="col-sm-4">
-            <i class="fa fa-fw fa-3x fa-group showcase-icon"></i>
-            <div class="showcase-desc">
-                <h2>
-                    <a href="{{ stache.config.peer_to_peer_entity_reference }}">Peer to Peer</a>
-                </h2>
-                <p>Describes the entity and type representations for common items that the Peer to Peer API uses.</p>
-            </div>
-        </div>
     </div>
 </div>

--- a/content/api/entity-reference/peer-to-peer/index.html
+++ b/content/api/entity-reference/peer-to-peer/index.html
@@ -1,0 +1,17 @@
+---
+layout: layout-container
+name: Peer to Peer
+order: 250
+published: true
+showInNav: true
+showBreadcrumbs: true
+---
+
+<div ng-app="entityReferenceApp">
+  <bb-entity-reference
+    api-title="Peer to Peer"
+    last-updated-date="March 14, 2017"
+    get-started-url="{{ stache.config.guide_getting_started }}"
+    swagger-url="https://reporting.everydayhero-staging.io/sky_peertopeer_api.json">
+  </bb-entity-reference>
+</div>

--- a/content/api/entity-reference/peer-to-peer/index.html
+++ b/content/api/entity-reference/peer-to-peer/index.html
@@ -2,8 +2,8 @@
 layout: layout-container
 name: Peer to Peer
 order: 250
-published: true
-showInNav: true
+published: false
+showInNav: false
 showBreadcrumbs: true
 ---
 

--- a/stache.yml
+++ b/stache.yml
@@ -52,6 +52,7 @@ files:
   js:
     - /assets/js/scrollreveal.js
     - /assets/js/custom.js
+    - /assets/js/entity-reference/app.js
 
 # =============================================
 # Disqus config
@@ -111,6 +112,7 @@ general_ledger_entity_reference: <%= stache.config.entity_reference %>general-le
 gift_entity_reference: <%= stache.config.entity_reference %>gift
 list_entity_reference: <%= stache.config.entity_reference %>list
 opportunity_entity_reference: <%= stache.config.entity_reference %>opportunity
+peer_to_peer_entity_reference: <%= stache.config.entity_reference %>peer-to-peer
 treasury_entity_reference: <%= stache.config.entity_reference %>treasury
 volunteer_entity_reference: <%= stache.config.entity_reference %>volunteer
 

--- a/static/assets/js/entity-reference/app.js
+++ b/static/assets/js/entity-reference/app.js
@@ -54,7 +54,25 @@
                         });
                     }
                     return entity;
-                });
+                })
+                .map(setDisplayTypesOnEntity);
+        }
+
+        function setDisplayTypesOnEntity(entity) {
+            Object.keys(entity.details.properties).forEach(function(propertyName) {
+                var property = entity.details.properties[propertyName];
+
+                if (property.type == "array") {
+                    var ref = property.items.$ref.replace("#/definitions/", "").toLowerCase();
+                    property.displayType = "array of " + ref;
+                } else if (property.$ref != undefined) {
+                    var ref = property.$ref.replace("#/definitions/", "").toLowerCase();
+                    property.displayType = ref;
+                } else {
+                    property.displayType = property.type;
+                }
+            });
+            return entity;
         }
     }
 })();

--- a/static/assets/js/entity-reference/app.js
+++ b/static/assets/js/entity-reference/app.js
@@ -1,0 +1,60 @@
+(function(){
+    "use strict";
+
+    var app = angular.module('entityReferenceApp', []);
+
+    app.controller('EntityReferenceCtrl', ['$http', EntityReferenceCtrl]);
+
+    app.component('bbEntityReference', {
+        templateUrl: '/assets/views/entities.html',
+        controller: 'EntityReferenceCtrl as ctrl',
+        bindings: {
+            apiTitle: '@',
+            lastUpdatedDate: '@',
+            getStartedUrl: '@',
+            swaggerUrl: '@',
+            whiteList: '@',
+            blackList: '@'
+        }
+    });
+
+    function EntityReferenceCtrl($http) {
+        this.title = 'Entity Reference';
+        this.showErrorMessage = false;
+
+        $http.get(this.swaggerUrl).then(handleSuccess.bind(this), handleError.bind(this));
+
+        function handleSuccess(response) {
+            var swagger = response.data;
+            this.swagger = swagger;
+            var whiteList = this.whiteList ? this.whiteList.split(',') : [];
+            var blackList = this.blackList ? this.blackList.split(',') : [];
+            this.entities = getEntitiesFromSwagger(swagger, whiteList, blackList);
+        }
+
+        function handleError(response) {
+            this.showErrorMessage = true;
+        }
+
+        function getEntitiesFromSwagger(swagger, whiteList, blackList) {
+            return Object.keys(swagger.definitions)
+                .sort()
+                .map(function(name) {
+                    return { name: name, details: swagger.definitions[name] };
+                })
+                .filter(function(entity) {
+                    if (whiteList.length > 0) {
+                        return whiteList.find(function(name) {
+                            return entity.name == name;
+                        });
+                    }
+                    if (blackList.length > 0) {
+                        return !blackList.find(function(name) {
+                            return entity.name == name;
+                        });
+                    }
+                    return entity;
+                });
+        }
+    }
+})();

--- a/static/assets/js/entity-reference/app.js
+++ b/static/assets/js/entity-reference/app.js
@@ -63,11 +63,15 @@
                 var property = entity.details.properties[propertyName];
 
                 if (property.type == "array") {
-                    var ref = property.items.$ref.replace("#/definitions/", "").toLowerCase();
-                    property.displayType = "array of " + ref;
-                } else if (property.$ref != undefined) {
-                    var ref = property.$ref.replace("#/definitions/", "").toLowerCase();
+                    var ref = property.items.$ref.replace("#/definitions/", "");
                     property.displayType = ref;
+                    property.ref = ref;
+                    property.isArrayRef = true;
+                } else if (property.$ref != undefined) {
+                    var ref = property.$ref.replace("#/definitions/", "");
+                    property.displayType = ref;
+                    property.ref = ref;
+                    property.isSingleRef = true;
                 } else {
                     property.displayType = property.type;
                 }

--- a/static/assets/views/entities.html
+++ b/static/assets/views/entities.html
@@ -35,7 +35,17 @@
             <tbody>
                 <tr ng-repeat="(property_name, property) in entity.details.properties">
                     <td>{{property_name}}</td>
-                    <td>{{property.displayType}}</td>
+                    <td>
+                        <a ng-show="property.isSingleRef" ng-href="#{{property.ref}}">
+                            {{property.displayType}}
+                        </a>
+                        <span ng-show="property.isArrayRef">
+                            array of <a ng-href="#{{property.ref}}">{{property.displayType}}</a>
+                        </span>
+                        <span ng-show="!property.isSingleRef && !property.isArrayRef">
+                            {{property.displayType}}
+                        </span>
+                    </td>
                     <td>{{property.description}}</td>
                 </tr>
             </tbody>

--- a/static/assets/views/entities.html
+++ b/static/assets/views/entities.html
@@ -35,7 +35,7 @@
             <tbody>
                 <tr ng-repeat="(property_name, property) in entity.details.properties">
                     <td>{{property_name}}</td>
-                    <td>{{property.type}}</td>
+                    <td>{{property.displayType}}</td>
                     <td>{{property.description}}</td>
                 </tr>
             </tbody>

--- a/static/assets/views/entities.html
+++ b/static/assets/views/entities.html
@@ -1,0 +1,44 @@
+
+<h1>{{ctrl.title}} Entity Reference</h1>
+<p>Updated: {{ctrl.lastUpdatedDate}}</p>
+
+<p>
+    This topic describes the entity and type representations for common items that the {{ctrl.title}} API uses. To learn
+    about how to set up your developer account and work with the SKY API, see the
+    <a ng-href="{{ ctrl.getStartedUrl }}">Getting Started</a> guide.
+</p>
+
+<p ng-show="ctrl.showErrorMessage" class="alert alert-danger">
+    There was an issue loading the Entity Reference for the {{ctrl.title}} API.
+</p>
+
+<ul id="entities">
+    <li ng-repeat="entity in ctrl.entities" style="margin: 0px">
+        <a ng-href="#{{entity.name}}">{{entity.name}}</a>
+    </li>
+</ul>
+
+<div ng-repeat="entity in ctrl.entities">
+    <a ng-attr-name="{{entity.name}}"></a>
+    <p>&nbsp;</p>
+    <h2>{{entity.name}}</h2>
+    <p>The <strong>{{entity.name}}</strong> entity has the following properties:</p>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th><strong>Property</strong></th>
+                    <th><strong>Type</strong></th>
+                    <th><strong>Description</strong></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="(property_name, property) in entity.details.properties">
+                    <td>{{property_name}}</td>
+                    <td>{{property.type}}</td>
+                    <td>{{property.description}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
Based on the work from @Blackbaud-JasonTremper . Changing the Entity Reference pages to use an Angular component to display Entity information from the Swagger JSON files.

Done:
* Entity Reference Angular component
  * Accepts swagger url as a binding
* Alphabetically order Entity definitions
* Anchor link tags for Entity names
* Replace existing project `index.html` files to use component
* Added Peer to Peer entity reference
* Can whitelist or blacklist entities to list in case swagger file has unnecessary entities (I believe swashbuckler is overzealous with some of the APIs according to a conversation with @Blackbaud-JasonTremper )
* Manually set last updated datetime

Work for another PR:
* Allow meta HTML content for an Entity
  * Example: Constituent - Address
* Read last updated datetime from swagger.info
