### PR TITLE
made caching relative to each API

### DIFF
--- a/static/assets/js/entity-reference/app.1.2.js
+++ b/static/assets/js/entity-reference/app.1.2.js
@@ -21,11 +21,12 @@
     function EntityReferenceCtrl($window, $http, $sce, $timeout, bbWait, localStorageService) {
         var self = this;
         this.showErrorMessage = false;
+        this.swaggerCacheName = 'swaggerResponseCache-' + this.apiTitle;
 
         this.$onInit = onInit;
 
         function onInit() {
-            var swaggerResponseCache = localStorageService.get('swaggerResponseCache-' + this.apiTitle);
+            var swaggerResponseCache = localStorageService.get(self.swaggerCacheName);
             bbWait.beginPageWait({});
 
             // Get a new swagger response if one is not cached or the cache has expired
@@ -44,7 +45,7 @@
             // Represents the number of hours until the cache expires
             var swaggerCacheHourLimit = 12;
 
-            localStorageService.set('swaggerResponseCache-' + self.apiTitle, {
+            localStorageService.set(self.swaggerCacheName, {
               'swaggerResponseData': response.data,
               'expirationDate': Date.now() + (swaggerCacheHourLimit * 36e5)
             });

--- a/static/assets/js/entity-reference/app.1.2.js
+++ b/static/assets/js/entity-reference/app.1.2.js
@@ -20,13 +20,12 @@
 
     function EntityReferenceCtrl($window, $http, $sce, $timeout, bbWait, localStorageService) {
         var self = this;
-        this.apiTitle = '';
         this.showErrorMessage = false;
 
         this.$onInit = onInit;
 
         function onInit() {
-            var swaggerResponseCache = localStorageService.get('swaggerResponseCache');
+            var swaggerResponseCache = localStorageService.get('swaggerResponseCache-' + this.apiTitle);
             bbWait.beginPageWait({});
 
             // Get a new swagger response if one is not cached or the cache has expired
@@ -45,7 +44,7 @@
             // Represents the number of hours until the cache expires
             var swaggerCacheHourLimit = 12;
 
-            localStorageService.set('swaggerResponseCache', {
+            localStorageService.set('swaggerResponseCache-' + self.apiTitle, {
               'swaggerResponseData': response.data,
               'expirationDate': Date.now() + (swaggerCacheHourLimit * 36e5)
             });


### PR DESCRIPTION
There was only one cache before and treasury entity ref was broken. Now there will be a cach for each respective API