### PR TITLE
changed key-name of entities to be display name

### DIFF
--- a/static/assets/js/entity-reference/app.1.2.js
+++ b/static/assets/js/entity-reference/app.1.2.js
@@ -82,7 +82,7 @@
                 .map(function(name) {
                     var definition = swagger.definitions[name];
                     return {
-                        name: name,
+                        name: definition['x-display-name'] || name,
                         displayName: definition['x-display-name'] || name,
                         details: definition,
                         additionalInfoHtml: $sce.trustAsHtml(definition['x-additional-info'])


### PR DESCRIPTION
The name used as the key for each entity was the name of the class, but will now use the displayname of the entity instead. This will fix the issue we are currently having where the entity Anchors have the name/id of "EntityRead". Now they will go back to being just "Entity" and the existing links will work again.