### PR TITLE
Changelog opportunity attachment tags

### DIFF
--- a/content/support/changelog/opportunity/index.html
+++ b/content/support/changelog/opportunity/index.html
@@ -14,20 +14,47 @@ title: Opportunity (Beta) Changelog
 
 Monitor this page to keep up with the [Opportunity API (Beta)]({{ stache.config.portal_endpoints_opportunity }}) latest changes and {{ stache.config.api_type_name }} service releases.
 
-## 2017-12-01
+## 2018-01-24
+
+### New
+
+Added the following endpoints:
+
+<div class="table-responsive">
+   <table class="table table-striped table-hover">
+      <thead>
+         <tr>
+            <th>Operation</th>
+            <th>Method</th>
+            <th>Route</th>
+         </tr>
+      </thead>
+         <tr class="clickable-row" data-url="{{ stache.config.portal_endpoints_opportunity_attachment_tags_get }}">
+            <td>Attachment tags</td>
+            <td>GET</td>
+            <td>/attachmenttags</td>
+         </tr>
+      </tbody>
+   </table>
+</div>
 
 ### Changed
+  
+We added the `date` property to the [attachment]({{ stache.config.opportunity_entity_reference }}#Attachment) entity.
+
+## 2017
+
+### 2017-12-01
+
+#### Changed
 
 The [Opportunity list endpoint]({{stache.config.portal_endpoints_opportunity_get_list}}) now includes an option to filter opportunities based on their associated constituents. The optional `constituent_id` query parameter, which can be specified multiple times to imply a logical OR, filters the results to only include opportunities associated with the specified constituent record IDs. For example, `&constituent_id=1242&constituent_id=385` filters the results to only include opportunities associated with two constituent records: "1242" and "385."
 
-## May 2017
 ### 2017-05-10
 
 #### Changed
 
 We updated the [Opportunity (GET)]({{ stache.config.portal_endpoints_opportunity_get }}) endpoint to return the `date_added` and `date_modified` properties.
-
-## April 2017
 
 ### 2017-04-27
 

--- a/stache.yml
+++ b/stache.yml
@@ -531,7 +531,7 @@ portal_endpoints_opportunity_attachment_get_list: <%= stache.config.portal_endpo
 portal_endpoints_opportunity_attachment_create: <%= stache.config.portal_endpoints_opportunity %>operations/58e3b27ba9db950fa048c8ae/
 portal_endpoints_opportunity_attachment_edit: <%= stache.config.portal_endpoints_opportunity %>operations/58e3b27ba9db950fa048c8b0/
 portal_endpoints_opportunity_attachment_delete: <%= stache.config.portal_endpoints_opportunity %>operations/58e3b27ba9db950fa048c8af/
-portal_endpoints_opportunity_attachment_tags_get: <%= stache.config.portal_endpoints_opportunity %>operations/TBD/
+portal_endpoints_opportunity_attachment_tags_get: <%= stache.config.portal_endpoints_opportunity %>operations/5a68e77fa9db951348db40ee/
 
 # =============================================
 # 			General Ledger API ENDPOINTS

--- a/stache.yml
+++ b/stache.yml
@@ -531,6 +531,7 @@ portal_endpoints_opportunity_attachment_get_list: <%= stache.config.portal_endpo
 portal_endpoints_opportunity_attachment_create: <%= stache.config.portal_endpoints_opportunity %>operations/58e3b27ba9db950fa048c8ae/
 portal_endpoints_opportunity_attachment_edit: <%= stache.config.portal_endpoints_opportunity %>operations/58e3b27ba9db950fa048c8b0/
 portal_endpoints_opportunity_attachment_delete: <%= stache.config.portal_endpoints_opportunity %>operations/58e3b27ba9db950fa048c8af/
+portal_endpoints_opportunity_attachment_tags_get: <%= stache.config.portal_endpoints_opportunity %>operations/TBD/
 
 # =============================================
 # 			General Ledger API ENDPOINTS


### PR DESCRIPTION
John, the previous changelog branch (#430) can be deleted since we had to make an emergency change last week.  This and a couple other changelog branches will address the original planned changes on an api basis.  This is for the Opportunity API and should be released when version 1.2.18017.1 makes it to PROD.  I will let you know when we are ready.  Let me know if you have any questions.