### PR TITLE
Renamed merchant account to payment configuration

### DIFF
--- a/content/docs/getting-started/payments/index.md
+++ b/content/docs/getting-started/payments/index.md
@@ -86,7 +86,7 @@ showInNav: false
 
 
 <ol>
-<li>From the <a href="https://developer.sky.blackbaud.com/docs/services/payments"><strong>Payments API Endpoint Reference</strong></a>, navigate to an endpoint such as <strong>GET Merchant account list</strong>, and click <strong>Try it</strong>. This activates the {{ stache.config.dev_console_name }}.</li>
+<li>From the <a href="https://developer.sky.blackbaud.com/docs/services/payments"><strong>Payments API Endpoint Reference</strong></a>, navigate to an endpoint such as <strong>GET Payment configuration list</strong>, and click <strong>Try it</strong>. This activates the {{ stache.config.dev_console_name }}.</li>
 <li>Under <strong>Query parameters</strong>, enter a parameter. For example, enter <code>true</code> for the <code>include_inactive</code> parameter.</li>
 <li>Under <strong>Headers</strong>, select the <strong>Show/Hide</strong> icon in the <code>{{ stache.config.subscription_keyname }}</code> field.  The value reflects one of your Payments API subscription keys.
 <p><bb-alert bb-alert-type="info"><strong><em>Note:</em></strong> The  <strong>Request URL</strong> and <strong>HTTP request</strong> change based on the values for the parameter and request header field values.</bb-alert></p></li>


### PR DESCRIPTION
Business side of Shared Services came in last second with a naming change. We've renamed the "merchant account" endpoints to be "payment configuration" endpoints. We just need to update this documentation to also reflect the change.