### PR TITLE
Updated Step 3 to call out correct subscription

### DIFF
--- a/content/docs/getting-started/payments/index.md
+++ b/content/docs/getting-started/payments/index.md
@@ -38,7 +38,10 @@ showInNav: false
 <div class="row">
   <div class="col-md-12" style="text-align: left;">
 <h3>How to get API subscription keys?</h3>
-<ol><li>To request a subscription to the Payments API, from the <strong><a href="https://developer.sky.blackbaud.com/products/">Products page</a></strong> select <strong>Payments API Preview</strong>. If you don't see this option, make sure you completed step 2.</li>
+<ol><li>To request a subscription to the Payments API, from the <strong><a href="https://developer.sky.blackbaud.com/products/">Products page</a></strong> select <strong>Payments API Preview</strong>. 
+  
+  <p><bb-alert bb-alert-type="info"><strong><em>Note:</em></strong>This is option is not <strong>SKY API Standard Edition</strong> subscription. If you don't see <strong>Payments API Preview</strong>, make sure you completed step 2.</bb-alert></p></li>
+ 
 <li>Click <strong>Review terms and subscribe</strong>. The SKY API Terms of Use will appear in a pop-up window.</li>
 <li>Review and agree to the Terms of Use.</li>
 <li>To submit your request, click <strong>Add subscription</strong>.</li></ol>


### PR DESCRIPTION
Updated Step 3 to call out correct subscription

I've added a note section to explicitly call out that the user will want Payments API Preview instead of SKY API Standard Edition. We have had several clients make this mistake so far.