### PR TITLE
Allowed email domains

### DIFF
--- a/static/web.config.hbs
+++ b/static/web.config.hbs
@@ -8,6 +8,7 @@
     <add key="ClientId" value="{{ bbauth.clientId }}" />
     <add key="ForbiddenContent" value="This site is restricted to Blackbaud staff members." />
     <add key="AnonymousPaths" value="{{ bbauth.anonymousPaths }}" />
+    <add key="AllowedEmailDomains" value="blackbaud.com;blackbaud.me;blackbaud.au;blackbaud.co.uk;blackbaud.ca;attentive.ly;microedge.com;smarttuition.com;everydayhero.com" />
     {{/if}}
   </appSettings>
   <system.webServer>


### PR DESCRIPTION
Necessary since our identity provider has changed for our email address to `@blackbaud.me` vs `@blackbaud.com`.